### PR TITLE
Minor tweaks

### DIFF
--- a/docs/home.mdx
+++ b/docs/home.mdx
@@ -16,7 +16,7 @@ If you encounter any issues or have questions about EssentialsX, feel free to jo
 ## Reporting Bugs
 Encountered a bug? Help us improve EssentialsX by reporting it. Here’s how you can report a bug effectively:
 
-* Check Existing Reports: Before submitting a new bug report, please check our [Bug Tracker](https://github.com/EssentialsX/Essentials/labels/bug%3A%20confirmed) to see if the issue has already been reported. This helps avoid duplicate reports.
+* Check Existing Reports: Before submitting a new bug report, please check our [Bug Tracker](https://github.com/EssentialsX/Essentials/issues?page=3&q=is%3Aopen+is%3Aissue+-label%3A%22misc%3A+pin%22+-label%3A%22type%3A+enhancement%22) to see if the issue has already been reported. This helps avoid duplicate reports.
 * Detailed Reports: When reporting a bug, be as detailed as possible. Include as much information as possible, including a link to a server dump `/ess dump all`, and any relevant error logs or screenshots. This information is crucial for us to understand and correct the issue.
 
 If you are unsure whether something is a bug, or just a misconfiguration, we encourage you to reach out to the Discord Support team!

--- a/docs/home.mdx
+++ b/docs/home.mdx
@@ -16,7 +16,7 @@ If you encounter any issues or have questions about EssentialsX, feel free to jo
 ## Reporting Bugs
 Encountered a bug? Help us improve EssentialsX by reporting it. Here’s how you can report a bug effectively:
 
-* Check Existing Reports: Before submitting a new bug report, please check our Bug Tracker to see if the issue has already been reported. This helps avoid duplicate reports.
+* Check Existing Reports: Before submitting a new bug report, please check our [Bug Tracker](https://github.com/EssentialsX/Essentials/labels/bug%3A%20confirmed) to see if the issue has already been reported. This helps avoid duplicate reports.
 * Detailed Reports: When reporting a bug, be as detailed as possible. Include as much information as possible, including a link to a server dump `/ess dump all`, and any relevant error logs or screenshots. This information is crucial for us to understand and correct the issue.
 
 If you are unsure whether something is a bug, or just a misconfiguration, we encourage you to reach out to the Discord Support team!

--- a/docs/home.mdx
+++ b/docs/home.mdx
@@ -16,7 +16,7 @@ If you encounter any issues or have questions about EssentialsX, feel free to jo
 ## Reporting Bugs
 Encountered a bug? Help us improve EssentialsX by reporting it. Here’s how you can report a bug effectively:
 
-* Check Existing Reports: Before submitting a new bug report, please check our [Bug Tracker](https://github.com/EssentialsX/Essentials/issues?page=3&q=is%3Aopen+is%3Aissue+-label%3A%22misc%3A+pin%22+-label%3A%22type%3A+enhancement%22) to see if the issue has already been reported. This helps avoid duplicate reports.
+* Check Existing Reports: Before submitting a new bug report, please check our [Bug Tracker](https://github.com/EssentialsX/Essentials/issues?q=is%3Aopen+is%3Aissue+-label%3A%22misc%3A+pin%22+-label%3A%22type%3A+enhancement%22) to see if the issue has already been reported. This helps avoid duplicate reports.
 * Detailed Reports: When reporting a bug, be as detailed as possible. Include as much information as possible, including a link to a server dump `/ess dump all`, and any relevant error logs or screenshots. This information is crucial for us to understand and correct the issue.
 
 If you are unsure whether something is a bug, or just a misconfiguration, we encourage you to reach out to the Discord Support team!

--- a/docs/modules/antibuild.mdx
+++ b/docs/modules/antibuild.mdx
@@ -2,7 +2,7 @@
 title: Anti-Build
 ---
 
-:::note
+:::warning
 This addon requires you to have a matching version of EssentialsX installed.
 :::
 

--- a/docs/modules/chat.mdx
+++ b/docs/modules/chat.mdx
@@ -6,7 +6,7 @@ This addon requires you to have a matching version of EssentialsX installed.
 :::
 
 :::note
-[Vault](https://github.com/milkbowl/Vault) is required if you wish to retrieve prefixes or suffixes from your permission manager. We recommend using [LuckPerms](https://luckperms.net/) as your permissions plugin.
+[Vault](https://github.com/milkbowl/Vault) is required if you wish to retrieve prefixes or suffixes from a permission manager.
 :::
 
 

--- a/docs/modules/chat.mdx
+++ b/docs/modules/chat.mdx
@@ -1,9 +1,12 @@
 ---
 title: Chat
 ---
-:::note
+:::warning
 This addon requires you to have a matching version of EssentialsX installed.
-You may also need [Vault](https://github.com/milkbowl/Vault) if you wish to get prefixes or suffixes from external plugins
+:::
+
+:::note
+[Vault](https://github.com/milkbowl/Vault) is required if you wish to retrieve prefixes or suffixes from your permission manager. We recommend using [LuckPerms](https://luckperms.net/) as your permissions plugin.
 :::
 
 

--- a/docs/modules/geoip.mdx
+++ b/docs/modules/geoip.mdx
@@ -2,7 +2,7 @@
 title: GeoIP
 ---
 
-:::note
+:::warning
 This addon requires you to have a matching version of EssentialsX installed.
 :::
 

--- a/docs/modules/protect.mdx
+++ b/docs/modules/protect.mdx
@@ -2,6 +2,6 @@
 title: Protect
 ---
 
-:::note
+:::warning
 This addon requires you to have a matching version of EssentialsX installed.
 :::

--- a/docs/modules/spawn.mdx
+++ b/docs/modules/spawn.mdx
@@ -2,7 +2,7 @@
 title: Spawn
 ---
 
-:::note
+:::warning
 This addon requires you to have a matching version of EssentialsX installed.
 :::
 

--- a/docs/modules/xmpp.mdx
+++ b/docs/modules/xmpp.mdx
@@ -2,6 +2,6 @@
 title: XMPP
 ---
 
-:::note
+:::warning
 This addon requires you to have a matching version of EssentialsX installed.
 :::


### PR DESCRIPTION
This PR replaces any occurences of the `note` admonition with `warning` for the mismatched module versions warning at the top of every module page and adds a masked link for the [Bug Tracker](https://github.com/EssentialsX/Essentials/labels/bug%3A%20confirmed) under the "Reporting Bugs" anchor in home.mdx.